### PR TITLE
add authorization header

### DIFF
--- a/RokuControlServer/server.js
+++ b/RokuControlServer/server.js
@@ -9,6 +9,7 @@ var dgram = require('dgram');
 // var rokuAddress = "http://192.168.1.100:8060/";
 var rokuAddress = null; 
 var PORT=1234; //this is the port you are enabling forwarding to. Reminder: you are port forwarding your public IP to the computer playing this script...NOT the roku IP
+var PASS='password' //this is the password used in the AWS lambda files to help stop others from running commands on your roku, should they guess your IP and port
 
 var ssdp = new Client();
 
@@ -462,6 +463,11 @@ var handlers = {
 
 //handles and incoming request by calling the appropriate handler based on the URL
 function handleRequest(request, response){
+    if (request.headers.authorization !== PASS) {
+        console.log("Invalid authorization header");
+        response.end();
+        return;
+    }
     if (handlers[request.url]) {
         handlers[request.url](request,response);
     } else {

--- a/RokuLambda/index.js
+++ b/RokuLambda/index.js
@@ -21,6 +21,7 @@ function sendCommand(path,body,callback) {
         port:serverinfo.port,
         path: path,
         method: 'POST',
+        headers: {'Authorization': serverinfo.pass},
     };
 
     var req = http.request(opt, function(res) {

--- a/RokuLambda/serverinfo_example.js
+++ b/RokuLambda/serverinfo_example.js
@@ -1,2 +1,3 @@
 exports.host = "127.0.0.1";
 exports.port = 1234;
+exports.pass = 'password';


### PR DESCRIPTION
Add support for a "password" by using the Authorization header. There might be a better way to do this, but I found it nice as a preventative measure.

I suppose this addition would also warrant updating the guide.