### PR TITLE
Add SSDP serviceType condition to SSDP response

### DIFF
--- a/RokuControlServer/server.js
+++ b/RokuControlServer/server.js
@@ -16,8 +16,10 @@ var rokuAddress = null;
 
 //handle the ssdp response when the roku is found
 ssdp.on('response', function (headers, statusCode, rinfo) {
-    rokuAddress = headers.LOCATION;
-    console.log("Found Roku: ",rokuAddress);
+    if ( headers.ST === 'roku:ecp' ) {
+        rokuAddress = headers.LOCATION;
+        console.log("Found Roku: ",rokuAddress);
+    }
 });
 
 //this is called periodically and will only look for the roku if we don't already have an address


### PR DESCRIPTION
Checks if the serviceType is equal to `'roku:ecp'`

Fixes problems Philips Hue being mistaken for Roku's; fixes #7